### PR TITLE
Add qBittorrent

### DIFF
--- a/.github/workflows/qbittorrent.yaml
+++ b/.github/workflows/qbittorrent.yaml
@@ -1,0 +1,83 @@
+name: qbittorrent
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Use this tag instead of most recent'
+        required: false
+      ignore-existing-tag:
+        description: 'Ignore existing tag if "true"'
+        required: false
+env:
+  IMAGES: ${{ github.repository_owner }}/${{ github.workflow }}
+  PLATFORMS: "linux/amd64,linux/arm64,linux/arm/v7"
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    outputs:
+      exists: ${{ steps.check-tag.outputs.exists }}
+      tag: ${{ steps.check-tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get Upstream Version
+        id: check
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]
+          then
+            VER=${{ github.event.inputs.tag }}
+          else
+            VER=$(curl -s https://api.github.com/repos/qbittorrent/qBittorrent/tags | jq --raw-output '.[0].name')
+            VER=${VER#*release-}
+          fi
+          echo "::set-env name=version::${VER}"
+      - uses: ./.github/actions/tag-check-action
+        name: Check Tag Against DockerHub
+        id: check-tag
+        with:
+          image: ${{ env.IMAGES }}
+          tag: ${{ github.event.inputs.tag || env.version }}
+          skip: ${{ github.event.inputs.ignore-existing-tag }}
+  multiarch:
+    needs: version-check
+    runs-on: ubuntu-latest
+    if: ${{ contains(needs.version-check.outputs.exists, 'false') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: ./.github/actions/docker-target-image-list-action
+        name: Generate Target Images
+        id: gen-tags
+        with:
+          images: ${{ env.IMAGES }}
+          tags: ${{ needs.version-check.outputs.tag }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+          version: latest
+          driver-opts: image=moby/buildkit:master
+      - name: Docker Multi Login
+        uses: ./.github/actions/docker-multi-login-action
+        env:
+          secrets: ${{ toJSON(secrets) }}
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./images/${{ github.workflow }}/Dockerfile
+          build-args: VERSION=${{ needs.version-check.outputs.tag }}
+          platforms: ${{ env.PLATFORMS }}
+          tags: ${{ steps.gen-tags.outputs.fully-qualified-target-images }}
+          pull: true
+          push: true
+      - name: Inspect
+        run: |
+          IFS=',' read -r -a images <<< "${{ steps.gen-tags.outputs.fully-qualified-target-images }}"
+          for image in "${images[@]}"; do
+              docker buildx imagetools inspect ${image}
+          done

--- a/images/qbittorrent/Dockerfile
+++ b/images/qbittorrent/Dockerfile
@@ -33,6 +33,7 @@ RUN \
   apt-get -qq update \
   && apt-get install -y --no-install-recommends \
     python3 \
+    libtorrent-rasterbar \
     p7zip-full \
     unrar \
     geoip-bin \

--- a/images/qbittorrent/Dockerfile
+++ b/images/qbittorrent/Dockerfile
@@ -33,7 +33,7 @@ RUN \
   apt-get -qq update \
   && apt-get install -y --no-install-recommends \
     python3 \
-    libtorrent-rasterbar \
+    libtorrent-rasterbar-dev \
     p7zip-full \
     unrar \
     geoip-bin \

--- a/images/qbittorrent/Dockerfile
+++ b/images/qbittorrent/Dockerfile
@@ -1,0 +1,56 @@
+FROM itscontained/ubuntu:focal-20200925 as builder
+
+ARG VERSION
+
+USER root
+
+RUN \
+  apt-get -qq update \
+  && apt-get -qq install -y --no-install-recommends \
+    build-essential cmake ninja-build pkg-config git zlib1g-dev libssl-dev libgeoip-dev \
+    libboost-dev libboost-system-dev libboost-chrono-dev libboost-random-dev \
+    qtbase5-dev qttools5-dev libqt5svg5-dev \
+    libtorrent-rasterbar-dev
+
+WORKDIR /tmp
+
+RUN git clone --depth 1 -b release-${VERSION} https://github.com/qbittorrent/qBittorrent.git . \
+    && ./configure --disable-gui \
+    && make \
+    && make install
+
+FROM itscontained/ubuntu:focal-20200925
+
+# Proper way to set config directory
+ENV HOME=/config \
+    XDG_CONFIG_HOME=/config \
+    XDG_DATA_HOME=/config \
+    WEBUI_PORT=8080
+
+USER root
+
+RUN \
+  apt-get -qq update \
+  && apt-get install -y --no-install-recommends \
+    p7zip-full \
+    unrar \
+    geoip-bin \
+    unzip \
+  && apt-get autoremove -y \
+  && apt-get clean \
+  && rm -rf \
+       /tmp/* \
+       /var/lib/apt/lists/* \
+       /var/tmp/ \
+  && echo umask ${UMASK} >> /etc/bash.bashrc
+
+USER itscontained
+
+RUN mkdir -p /app/qbittorrent/bin /config/qBittorrent/qBittorrent.conf /tmp/incomplete
+
+COPY --from=builder /usr/local/bin/qbittorrent-nox /app/qbittorrent/bin/qbittorrent
+COPY qBittorrent.conf /config/qBittorrent
+
+EXPOSE 6881 6881/udp ${WEBUI_PORT}
+
+CMD umask ${UMASK} && /app/qbittorrent/bin/qbittorrent --webui-port="${WEBUI_PORT}"

--- a/images/qbittorrent/Dockerfile
+++ b/images/qbittorrent/Dockerfile
@@ -15,7 +15,7 @@ RUN \
 WORKDIR /tmp
 
 RUN git clone --depth 1 -b release-${VERSION} https://github.com/qbittorrent/qBittorrent.git . \
-    && ./configure --disable-gui \
+    && ./configure --disable-gui --disable-stacktrace \
     && make \
     && make install
 
@@ -33,7 +33,9 @@ RUN \
   apt-get -qq update \
   && apt-get install -y --no-install-recommends \
     python3 \
-    libtorrent-rasterbar-dev \
+    libtorrent-rasterbar9 \
+    libqt5network5 \
+    libqt5xml5 \
     p7zip-full \
     unrar \
     geoip-bin \

--- a/images/qbittorrent/Dockerfile
+++ b/images/qbittorrent/Dockerfile
@@ -32,6 +32,7 @@ USER root
 RUN \
   apt-get -qq update \
   && apt-get install -y --no-install-recommends \
+    python3 \
     p7zip-full \
     unrar \
     geoip-bin \

--- a/images/qbittorrent/README.md
+++ b/images/qbittorrent/README.md
@@ -1,0 +1,16 @@
+# [itscontained/qbittorrent](https://github.com/itscontained/qbittorrent)
+[![Github Workflow](https://img.shields.io/github/workflow/status/itscontained/qbittorrent/Check%20and%20Push?labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/itscontained/qbittorrent/actions?query=workflow%3A%22Check+and+Push%22)
+[![GitHub Stars](https://img.shields.io/github/stars/itscontained/qbittorrent.svg?color=00E5D2&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/itscontained/qbittorrent)
+[![Docker Version](https://img.shields.io/docker/v/itscontained/qbittorrent.svg?sort=semver&color=00E5D2&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=docker)](https://hub.docker.com/r/itscontained/qbittorrent/tags)
+[![Docker Image Size](https://img.shields.io/docker/image-size/itscontained/qbittorrent.svg?sort=semver&color=00E5D2&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=docker)](https://hub.docker.com/r/itscontained/qbittorrent/tags)
+[![MicroBadger Layers](https://img.shields.io/microbadger/layers/itscontained/qbittorrent.svg?color=00E5D2&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=docker)](https://microbadger.com/images/itscontained/qbittorrent)
+[![Docker Pulls](https://img.shields.io/docker/pulls/itscontained/qbittorrent.svg?color=00E5D2&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=pulls&logo=docker)](https://hub.docker.com/r/itscontained/qbittorrent)
+[![Docker Stars](https://img.shields.io/docker/stars/itscontained/qbittorrent.svg?color=00E5D2&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=stars&logo=docker)](https://hub.docker.com/r/itscontained/qbittorrent)
+[![Discord](https://img.shields.io/discord/734273194818535474?color=00E5D2&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=discord&logo=discord)](https://discord.gg/eT6crpT)
+
+## Supported Architectures
+The architectures supported by this image are:
+
+| Architecture | Tag |
+| :----: | --- |
+| x86-64 | latest |

--- a/images/qbittorrent/qBittorrent.conf
+++ b/images/qbittorrent/qBittorrent.conf
@@ -1,0 +1,15 @@
+[AutoRun]
+enabled=false
+program=
+
+[LegalNotice]
+Accepted=true
+
+[Preferences]
+Connection\UPnP=false
+Connection\PortRangeMin=6881
+Downloads\SavePath=/tmp/
+Downloads\ScanDirsV2=@Variant(\0\0\0\x1c\0\0\0\0)
+Downloads\TempPath=/tmp/incomplete/
+WebUI\Address=*
+WebUI\ServerDomains=*


### PR DESCRIPTION
LSIO is building images from what returns from this

```
curl -sX GET http://ppa.launchpad.net/qbittorrent-team/qbittorrent-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz | gunzip -c | grep -A 7 -m 1 "Package: qbittorrent-nox" | awk -F": " '/Version/{print $3;exit}'
```

and they proceed to install qbittorrent with apt. 

From what I can tell there is no way to have a semver tag on this docker image using the apt install method. I have gone the route of compiling qBittorrent from source, which gives us this ability, but we have slower build times.